### PR TITLE
Enable S3 compatible storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN cargo build --release
 
 FROM debian:buster-slim
 RUN apt-get update \
-    && apt-get -y install clang
+    && apt-get -y install clang ca-certificates
 RUN mkdir -p /etc/myst          \
     && mkdir -p /var/log/myst   \
     && mkdir -p /var/myst/data  \

--- a/src/s3/processor.rs
+++ b/src/s3/processor.rs
@@ -46,6 +46,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread;
 use std::time::SystemTime;
+use std::str::FromStr;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
@@ -67,6 +68,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut key_prefix = format!("{}/{}", namespace, start_time);
     let mut running_time = start_time;
 
+    let region_name = config.aws_region;
+    let region = match Region::from_str(&region_name) {
+        Ok(region) => region,
+        Err(_) => {
+            Region::Custom {
+                name: region_name,
+                endpoint: config.aws_endpoint
+            }
+        },
+    };
+
     loop {
         let key = config.aws_key.as_str();
         let secret = config.aws_secret.as_str();
@@ -75,7 +87,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let s3_client = S3Client::new_with(
             HttpClient::new().expect("Failed to create client"),
             StaticProvider::from(creds),
-            Region::UsEast2,
+            region.clone(),
         );
 
         let mut list_request = ListObjectsRequest::default();

--- a/src/s3/segment_download.rs
+++ b/src/s3/segment_download.rs
@@ -23,6 +23,7 @@ use crate::s3::remote_store::RemoteStore;
 use log::{error, info};
 use std::fs::{create_dir_all, read_dir, rename, File};
 use std::path::Path;
+use std::str::FromStr;
 use std::{
     collections::HashSet,
     io::Error,
@@ -326,10 +327,22 @@ pub async fn start_download() -> Result<(), Box<dyn std::error::Error>> {
     let root_data_path = config.data_download_path;
     let temp_data_path = config.temp_data_path;
     let frequency = config.download_frequency;
+
+    let region_name = config.aws_region;
+    let region = match Region::from_str(&region_name) {
+        Ok(region) => region,
+        Err(_) => {
+            Region::Custom {
+                name: region_name,
+                endpoint: config.aws_endpoint
+            }
+        },
+    };
+
     let s3_client = S3Client::new_with(
         HttpClient::new().expect("Failed to create client"),
         StaticProvider::from(creds),
-        Region::UsEast2,
+        region
     );
 
     let arc_s3_client = Arc::new(s3_client);

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -48,6 +48,8 @@ pub struct Config {
     pub processed_bucket: String,
     pub aws_key: String,
     pub aws_secret: String,
+    pub aws_region: String,
+    pub aws_endpoint: String,
     pub temp_data_path: String,
     pub download_frequency: u64,
 
@@ -101,6 +103,8 @@ impl Config {
             processed_bucket: config.get_str("processed_bucket").unwrap().to_string(),
             aws_key: config.get_str("aws_key").unwrap().to_string(),
             aws_secret: config.get_str("aws_secret").unwrap().to_string(),
+            aws_region: config.get_str("aws_region").unwrap().to_string(),
+            aws_endpoint: config.get_str("aws_endpoint").unwrap_or("".to_string()),
             temp_data_path: config.get_str("temp_data_path").unwrap().to_string(),
             download_frequency: config.get_int("download_frequency").unwrap() as u64,
             plugin_path: config.get_str("plugin_path").unwrap(),


### PR DESCRIPTION
## Issue
We want to use localhost or remote AWS S3 compatible storage as a storage location for metadata and segments.
Therefore, region name and endpoint can be specified as setting values.

## Usage
### Using AWS S3
Please add the settings as below.
```
aws_region = "us-east-2"
```

### Using other Remote Storage
Please set the region name and endpoint.
```
aws_region = "<region name>"
aws_endpoint = "<http://foo.bar.com/>"
```
